### PR TITLE
添加选项：是否翻译包含中文的文本

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ npm-debug.log
 configs/crx.pem
 build.crx
 build.zip
+.history
+.package-lock.json

--- a/src/components/options_app.js
+++ b/src/components/options_app.js
@@ -125,6 +125,8 @@ class App extends Component {
     const changeActiveType = this.changeOptions.bind(this, 'activeType')
     // eslint-disable-next-line
     const changeShowNotebook = this.changeOptions.bind(this, 'showNotebook')
+    // eslint-disable-next-line
+    const changeShowContainChinese = this.changeOptions.bind(this, 'showContainChinese')
 
     if (!inited) {
       return null
@@ -132,6 +134,7 @@ class App extends Component {
 
     const showNotebook = options.showNotebook
     const activeType = options.activeType
+    const showContainChinese = options.showContainChinese
 
     return (
       <div style={styles.container}>
@@ -219,6 +222,25 @@ class App extends Component {
                 <span style={styles.label}>{ACTIVE_TYPES[type]}</span>
               </div>
             ))}
+          </div>
+        </div>
+        <div style={styles.item}>
+          <div style={styles.itemTitle}>
+            中文翻译设置：
+          </div>
+          <div style={styles.activeTypeContainer}>
+            <div
+              style={styles.activeTypeItem}
+              onClick={() => changeShowContainChinese(!showContainChinese)}
+            >
+              <input
+                name="showContainChinese"
+                type="radio"
+                style={styles.radio}
+                checked={showContainChinese}
+              />
+              <span style={styles.label}>包含中文时显示翻译</span>
+            </div>
           </div>
         </div>
         <div>

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -175,7 +175,6 @@ function render(options, hide) {
 
   const content = selection.toString().trim()
   if (!options.showContainChinese && hasChinese(content)) {
-    console.log('has chinese')
     return
   }
   const containerEle = getContainer()

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -157,6 +157,13 @@ function createSelectionStream(next, options) {
   })
 }
 
+function hasChinese(text) {
+  if (/.*[\u4e00-\u9fa5]+.*$/.test(text)) { // 包含汉字
+    return true
+  }
+  return false
+}
+
 function render(options, hide) {
   const selection = window.getSelection()
   const position = getPosition(selection)
@@ -165,11 +172,15 @@ function render(options, hide) {
     return
   }
 
-  const containerEle = getContainer()
+
   const content = selection.toString().trim()
+  if (!options.showContainChinese && hasChinese(content)) {
+    console.log('has chinese')
+    return
+  }
+  const containerEle = getContainer()
   const node = selection.baseNode
   const lineHeight = getElementLineHeight(node)
-
   ReactDOM.render(
     <ContentApp
       lineHeight={lineHeight}


### PR DESCRIPTION
在选项页添加了一个新的选项：是否在 包含中文时显示翻译，并添加相关代码

![screen shot 2018-01-19 at 16 27 21](https://user-images.githubusercontent.com/2994445/35141391-c35e397e-fd35-11e7-85a4-d07aba73ae95.png)

