### PR TITLE
fix Nodename error, remove addWord, update REAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![build](https://api.travis-ci.org/oyyd/youdao-collins-chrome-extension.svg?branch=master)](https://travis-ci.org/oyyd/youdao-collins-chrome-extension)
 
-查询英文单词的[柯林斯](https://www.collinsdictionary.com/)释义的chrome扩展应用。支持划词翻译，数据来源于有道词典。接入扇贝生词本，快速记录新单词，方便未来复习。
+查询英文单词的[柯林斯](https://www.collinsdictionary.com/)释义的chrome扩展应用。支持划词翻译，数据来源于有道词典。
 
 ![intro](https://oyyd.github.io/youdao-collins-chrome-extension/pics/intro.webp)
 
@@ -15,7 +15,7 @@
   - 按住(meta/ctrl)键 + 划词时翻译
   - 双击划词翻译
 - 快捷键`ctrl+q`打开右上角浮层，用于搜索单词
-- 搜索成功的单词可以快速加入到扇贝生词本（词库，oauth接入，需要你有扇贝的帐号）中，用于复习
+- <del>搜索成功的单词可以快速加入到扇贝生词本（词库，oauth接入，需要你有扇贝的帐号）中，用于复习</del> *因为扇贝网关闭了 API，此功能不再提供。*
 
 ## 功能介绍
 
@@ -39,7 +39,7 @@ chrome store上已经有很多其他词典来满足一般的英文词语意义�
 
 改扩展的数据源来源于[有道词典](http://dict.youdao.com/)，但并没有通过api访问，而是直接获取页面内容再加工，理论上也就不会被api访问上线次数限制。
 
-### 4. 接入扇贝生词本（词库）
+### 4. <del>接入扇贝生词本（词库）</del> *因为扇贝网关闭了 API，此功能不再提供。*
 
 市面上英语学习的软件不少，扇贝是其中之一。但我个人觉得扇贝是少数在探索如何将软件技术和语言学习有效地结合起来的产品之一，也是这个应用最后选择接入扇贝生词本的重要原因（虽然扇贝的“清空词库”功能是已经实现的功能，但却严格限制用户使用这一点，会让我这样只使用其中部分功能的用户非常费解）。通过生词本，我们每天多花一点时间复习今天碰到的单词。这让这个软件在教育、学习的层面上多了不少价值。
 

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 2,
 
-  "name": "划词翻译(柯林斯词典)+扇贝生词本",
-  "description": "查询单词柯林斯释义，支持划词翻译，数据来源于有道词典。接入扇贝生词本，快速记录新单词，方便未来学习。",
-  "version": "1.0",
+  "name": "划词翻译(柯林斯词典)",
+  "description": "查询单词柯林斯释义，支持划词翻译，数据来源于有道词典。",
+  "version": "1.2.3",
 
   "icons": {
     "16": "./icons/icon16.png",
@@ -44,7 +44,6 @@
     "storage",
     "activeTab",
     "tabs",
-    "http://dict.youdao.com/",
-    "https://api.shanbay.com/"
+    "http://dict.youdao.com/"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "youdao-collins-chrome-extension",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2347,18 +2347,26 @@
       }
     },
     "elliptic": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
         "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        }
       }
     },
     "emoji-regex": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2347,9 +2347,9 @@
       }
     },
     "elliptic": {
-      "version": "6.5.1",
-      "resolved": "http://bnpm.byted.org/elliptic/download/elliptic-6.5.1.tgz",
-      "integrity": "sha1-w4D1+Qm/G5tEKNAozRjTsO/WtSs=",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
@@ -2889,12 +2889,6 @@
       "version": "1.0.5",
       "resolved": "http://bnpm.byted.org/eventemitter2/download/eventemitter2-1.0.5.tgz",
       "integrity": "sha1-+YNhBRexc3wLncZDvsqTiTwE3xg=",
-      "dev": true
-    },
-    "eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
       "dev": true
     },
     "events": {
@@ -3843,21 +3837,28 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.2.0",
-      "resolved": "http://bnpm.byted.org/handlebars/download/handlebars-4.2.0.tgz",
-      "integrity": "sha1-V86NIXW5u7PYs88+Qhexrsjdyy4=",
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
       "dev": true,
       "requires": {
+        "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
-        "optimist": "^0.6.1",
         "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
       },
       "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "http://bnpm.byted.org/source-map/download/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
       }
@@ -4046,14 +4047,22 @@
       }
     },
     "http-proxy": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
-      "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
       "dev": true,
       "requires": {
-        "eventemitter3": "^3.0.0",
+        "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
         "requires-port": "^1.0.0"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "4.0.7",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+          "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+          "dev": true
+        }
       }
     },
     "http-server": {
@@ -5121,9 +5130,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "http://bnpm.byted.org/lodash/download/lodash-4.17.15.tgz",
-      "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg=",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "longest": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youdao-collins-chrome-extension",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "A chrome extension to help you search english words in collins dict.",
   "main": "index.js",
   "scripts": {

--- a/src/components/detail.js
+++ b/src/components/detail.js
@@ -2,7 +2,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import Audio from './audio'
-import AddWord from './add_word'
 import icons from './icons'
 import Tips from './tips'
 import { mainBG, fontS, gapL, gapM, gapS, colorDanger,
@@ -128,7 +127,6 @@ function renderWordBasic(
   synonyms: ?SynonymsType,
   search: ?(word: string) => void,
   showWordsPage: boolean,
-  showNotebook: boolean,
   flash: () => {},
 ) {
   const { word, pronunciation, frequence, rank, additionalPattern } = wordInfo
@@ -174,15 +172,7 @@ function renderWordBasic(
         <span style={styles.infoItem}>
           <Audio word={word} />
         </span>
-        {showNotebook ? (
-          <span style={styles.infoItem}>
-            <AddWord
-              word={word}
-              showWordsPage={showWordsPage}
-              flash={flash}
-            />
-          </span>
-        ) : null}
+
         {frequence ? (
           <span style={Object.assign({}, styles.infoItem, { color: colorWarning })}>
             {renderFrequence(frequence)}
@@ -259,7 +249,7 @@ function renderChoices(response: ChoiceResponseType, searchWord) {
 function renderNonCollins(
   currentWord, navigate,
   response?: NonCollinsExplainsResponseType,
-  showWordsPage?: boolean, showNotebook?: boolean,
+  showWordsPage?: boolean,
   flash: () => {},
 ) {
   const wordBasic = (response && response)
@@ -268,7 +258,6 @@ function renderNonCollins(
       null,
       null,
       Boolean(showWordsPage),
-      Boolean(showNotebook),
       flash,
     ) : null
 
@@ -336,11 +325,10 @@ class Detail extends Component {
   renderContent() {
     const { flash } = this
     const { search, currentWord, explain: wordResponse,
-      openLink, showWordsPage, showNotebook } = this.props
+      openLink, showWordsPage } = this.props
     const openCurrentWord = openLink.bind(null, currentWord)
     const renderErr = renderNonCollins.bind(null, currentWord,
-      openCurrentWord, undefined, showWordsPage,
-      showNotebook, flash,
+      openCurrentWord, undefined, showWordsPage, flash,
     )
 
     if (!wordResponse) {
@@ -350,13 +338,13 @@ class Detail extends Component {
     const { response, type } = wordResponse
 
     if (type === 'explain') {
-      return renderExplain(response, showWordsPage, showNotebook, search, flash)
+      return renderExplain(response, showWordsPage, search, flash)
     } else if (type === 'choices') {
       return renderChoices(response, search)
     } else if (type === 'non_collins_explain') {
       return renderNonCollins(
         currentWord, openCurrentWord, response,
-        showWordsPage, showNotebook, flash,
+        showWordsPage, flash,
       )
     } else if (type === 'machine_translation') {
       return renderMachineTranslation(response)
@@ -386,8 +374,7 @@ Detail.propTypes = {
   explain: object,
   search: func.isRequired,
   openLink: func.isRequired,
-  showWordsPage: bool.isRequired,
-  showNotebook: bool.isRequired,
+  showWordsPage: bool.isRequired
 }
 
 // $FlowFixMe

--- a/src/components/options_app.js
+++ b/src/components/options_app.js
@@ -138,7 +138,10 @@ class App extends Component {
 
     return (
       <div style={styles.container}>
-        <div style={styles.item}>
+        <div
+          style={Object.assign({}, styles.item, {
+            display: 'none'
+          })}>
           <div style={styles.itemTitle}>扇贝单词本设置：</div>
           {hasClearToken ? (
             <div style={styles.saveTips}>
@@ -184,7 +187,7 @@ class App extends Component {
                 name="showNotebook"
                 type="radio"
                 style={styles.radio}
-                checked={showNotebook}
+                defaultChecked={showNotebook}
               />
               <span style={styles.label}>开启</span>
             </div>
@@ -196,7 +199,7 @@ class App extends Component {
                 name="showNotebook"
                 type="radio"
                 style={styles.radio}
-                checked={!showNotebook}
+                defaultChecked={!showNotebook}
               />
               <span style={styles.label}>关闭</span>
             </div>
@@ -217,7 +220,7 @@ class App extends Component {
                   name="activeType"
                   type="radio"
                   style={styles.radio}
-                  checked={activeType === type}
+                  defaultChecked={activeType === type}
                 />
                 <span style={styles.label}>{ACTIVE_TYPES[type]}</span>
               </div>
@@ -237,7 +240,7 @@ class App extends Component {
                 name="showContainChinese"
                 type="radio"
                 style={styles.radio}
-                checked={showContainChinese}
+                defaultChecked={showContainChinese}
               />
               <span style={styles.label}>包含中文时显示翻译</span>
             </div>

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -66,22 +66,26 @@ function getPosition(selection) {
   }
 
   const elem = range.startContainer.firstElementChild
-  if (elem !== undefined) {
-    if (elem.nodeName === 'INPUT' || elem.nodeName === 'TEXTAREA') {
-      const { top, left } = elem.getBoundingClientRect()
-      const rectStart = getCaretCoordinates(elem, elem.selectionStart)
-      const rectEnd = getCaretCoordinates(elem, elem.selectionEnd)
-      if (!rectEnd) {
-        return null
-      }
-      rect = {
-        top: top + rectEnd.top,
-        left: left + rectEnd.left,
-        width: rectEnd.left - rectStart.left,
-      }
+
+  if (elem && elem !== undefined && elem.nodeName && (elem.nodeName === 'INPUT' || elem.nodeName === 'TEXTAREA')) {
+    const { top, left } = elem.getBoundingClientRect()
+    const rectStart = getCaretCoordinates(elem, elem.selectionStart)
+    const rectEnd = getCaretCoordinates(elem, elem.selectionEnd)
+
+    if (!rectEnd) {
+      return null
+    }
+    rect = {
+      top: top + rectEnd.top,
+      left: left + rectEnd.left,
+      width: rectEnd.left - rectStart.left,
     }
   } else {
     rect = range.getBoundingClientRect()
+  }
+
+  if (!rect) {
+    return null
   }
 
   const { top, left, width } = rect


### PR DESCRIPTION
1. 修复安装此插件后，鼠标点击页面空白处时提示 `Nodename` 未定义的报错（具体表现为点击页面空白时 console 里会报错，但用户并无感知）
2. 修复插件 options 页面中 `defaultChecked` 的相关报错。（这个报错不会影响到用户，但开发者在插件的错误收集页面会看到）
3. 因为扇贝网关闭了 API （issue : https://github.com/oyyd/youdao-collins-chrome-extension/issues/47 ），所以移除了「点击加入扇贝词库」的按钮。（代码还保留，只不过不展示了）
4. 更新了 README 中关于 “加入到扇贝生词本” 的介绍，解释不再提供此功能的原因。
5. 修改版本号为 `1.2.3`
6. 依赖包更新：
  Bump http-proxy from 1.17.0 to 1.18.1 dependencies
  #52 opened on Sep 10 by dependabot bot
  Bump handlebars from 4.2.0 to 4.7.6 dependencies
  #51 opened on Sep 7 by dependabot bot
  Bump elliptic from 6.5.1 to 6.5.3 dependencies
  #49 opened on Aug 1 by dependabot bot
  Bump lodash from 4.17.15 to 4.17.19 dependencies
  #48 opened on Jul 18 by dependabot bot
  上面这几个 @dependabot 的 PR 可以 close 啦

@oyyd review plz
