### PR TITLE
fix: issue/39 Uncaught TypeError: Cannot read property 'nodeName' of …

### DIFF
--- a/src/content_script.js
+++ b/src/content_script.js
@@ -235,6 +235,14 @@ function render(options, hide) {
 
 function main() {
   getOptions().then((options) => {
+    window.addEventListener('message', ({data})=>{
+        if (!data || data.type !== 'ycce') {
+            return
+        }
+        if(data.action == 'hide') {
+            render(options, true)
+        }
+    })
     chrome.runtime.onMessage.addListener((msg) => {
       if (msg.type !== 'ycce') {
         return

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -66,7 +66,7 @@ function getPosition(selection) {
   }
 
   const elem = range.startContainer.firstElementChild
-  if (elem !== undefined) {
+  if (elem != null) {
     if (elem.nodeName === 'INPUT' || elem.nodeName === 'TEXTAREA') {
       const { top, left } = elem.getBoundingClientRect()
       const rectStart = getCaretCoordinates(elem, elem.selectionStart)
@@ -80,7 +80,8 @@ function getPosition(selection) {
         width: rectEnd.left - rectStart.left,
       }
     }
-  } else {
+  }
+  if (!rect) {
     rect = range.getBoundingClientRect()
   }
 


### PR DESCRIPTION
this PR should fix: https://github.com/oyyd/youdao-collins-chrome-extension/issues/39

The logic retuned:

1. When `firstElementChild` is empty, the returned value should be checked against `null`
2. When it's not `INPUT` or `TEXTAREA`, then fallback to `range.getBoundingClientRect`
